### PR TITLE
Problem: Race condition on token get/create

### DIFF
--- a/django_cyverse_auth/__init__.py
+++ b/django_cyverse_auth/__init__.py
@@ -2,5 +2,5 @@
 from collections import namedtuple
 
 version_info = namedtuple("version_info", ["major", "minor", "patch"])
-version = version_info(1, 0, 15)
+version = version_info(1, 0, 16)
 __version__ = "{0.major}.{0.minor}.{0.patch}".format(version)

--- a/django_cyverse_auth/__init__.py
+++ b/django_cyverse_auth/__init__.py
@@ -2,5 +2,5 @@
 from collections import namedtuple
 
 version_info = namedtuple("version_info", ["major", "minor", "patch"])
-version = version_info(1, 0, 16)
+version = version_info(1, 1, 0)
 __version__ = "{0.major}.{0.minor}.{0.patch}".format(version)

--- a/django_cyverse_auth/authBackends.py
+++ b/django_cyverse_auth/authBackends.py
@@ -17,7 +17,7 @@ from keystoneclient.v3 import client
 
 
 from .settings import auth_settings
-from .models import get_or_create_user, create_user_and_token
+from .models import get_or_create_user, get_or_create_token
 from .models import Token
 from .protocol.ldap import ldap_validate, ldap_formatAttrs
 from .protocol.ldap import lookupUser as ldap_lookupUser
@@ -113,7 +113,8 @@ class LDAPLoginBackend(ModelBackend):
         return self._update_token(attributes, token, request)
 
     def _update_token(self, user_profile, token, request=None):
-        auth_token = create_user_and_token(user_profile, token, issuer="LDAPLoginBackend")
+        user = get_or_create_user(user_profile['username'], user_profile)
+        auth_token = get_or_create_token(user, token, issuer="OpenstackLoginBackend")
         user = auth_token.user
         if request:
             request.session['token_key'] = auth_token.key
@@ -462,7 +463,8 @@ class OpenstackLoginBackend(ModelBackend):
 
     def _update_token(self, auth_url, username, token, expiry_time, request=None):
         user_profile = self._user_profile_for_auth(auth_url, username)
-        auth_token = create_user_and_token(user_profile, token, token_expire=expiry_time, issuer="OpenstackLoginBackend")
+        user = get_or_create_user(user_profile['username'], user_profile)
+        auth_token = get_or_create_token(user, token, token_expire=expiry_time, issuer="OpenstackLoginBackend")
         user = auth_token.user
         if request:
             request.session['token_key'] = auth_token.key

--- a/django_cyverse_auth/protocol/globus.py
+++ b/django_cyverse_auth/protocol/globus.py
@@ -9,7 +9,7 @@ from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.client import Error as OAuthError
 
 from django_cyverse_auth.models import (
-    get_or_create_user, create_user_and_token,
+    get_or_create_user, get_or_create_token,
     create_access_token, get_access_token)
 from django_cyverse_auth.settings import auth_settings
 from django_cyverse_auth.exceptions import Unauthorized
@@ -193,7 +193,8 @@ def globus_validate_code(request):
         'lastName':last_name,
         'email': email,
     }
-    auth_token = create_user_and_token(user_profile, user_access_token, expiry_date, issuer)
+    user = get_or_create_user(user_profile['username'], user_profile)
+    auth_token = get_or_create_token(user, user_access_token, token_expire=expiry_date, issuer="OpenstackLoginBackend")
     return auth_token
 
 def create_user_token_from_globus_profile(profile, access_token):
@@ -219,6 +220,6 @@ def create_user_token_from_globus_profile(profile, access_token):
         'lastName':last_name,
         'email': email,
     }
-    auth_token = create_user_and_token(profile_dict, access_token, expiry, issuer)
+    user = get_or_create_user(profile_dict['username'], profile_dict)
+    auth_token = get_or_create_token(user, access_token, token_expire=expiry, issuer=issuer)
     return auth_token
-

--- a/django_cyverse_auth/protocol/jwt_oauth.py
+++ b/django_cyverse_auth/protocol/jwt_oauth.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from django_cyverse_auth.models import create_token
+from django_cyverse_auth.models import get_or_create_token
 
 
 class JWTServiceProvider():
@@ -23,7 +23,7 @@ class JWTServiceProvider():
         """
         decoded_assertion = self.decode_assertion(jwt_assertion)
         user, expiration = self.validate_assertion(decoded_assertion)
-        auth_token = create_token(user.username, expiration)
+        auth_token = get_or_create_token(user.username, expiration)
         return auth_token
 
     @abstractmethod

--- a/django_cyverse_auth/session.py
+++ b/django_cyverse_auth/session.py
@@ -5,13 +5,13 @@ session authentication
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
 
-from .models import Token as AuthToken, create_token
+from .models import Token as AuthToken, get_or_create_token
 from .settings import auth_settings
 
 # Login Hooks here:
 def create_session_token(sender, user, request, issuer="Django-Session", **kwargs):
-    auth_token = create_token(user, issuer=issuer)
-    auth_token.update_expiration() # 2hr default expiry
+    auth_token = get_or_create_token(user, issuer=issuer)
+    auth_token.expireTime = AuthToken.update_expiration() # Expiration time based on auth_settings
     auth_token.save()
     request.session['username'] = auth_token.user.username
     request.session['token'] = auth_token.key

--- a/django_cyverse_auth/views.py
+++ b/django_cyverse_auth/views.py
@@ -13,7 +13,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 import logging
 logger = logging.getLogger(__name__)
 
-from .models import create_token, userCanEmulate
+from .models import get_or_create_token, userCanEmulate
 from .models import Token as AuthToken
 from .protocol.cas import cas_validateUser, cas_loginRedirect, get_cas_oauth_client
 from .protocol.globus import globus_logout, globus_authorize, globus_validate_code
@@ -123,7 +123,7 @@ def cas_callback_authorize(request):
     # ASSERT: A valid OAuth token gave us the Users Profile.
     # Now create an AuthToken and return it
     username = user_profile["id"]
-    auth_token = create_token(username, access_token, expiry_date, issuer="CAS+OAuth")
+    auth_token = get_or_create_token(username, access_token, expiry_date, issuer="CAS+OAuth")
     # Set the username to the user to be emulated
     # to whom the token also belongs
     request.session['username'] = username
@@ -158,7 +158,7 @@ def token_auth(request):
     # LDAP Authenticate if password provided.
     if username and password:
         if ldap_validate(username, password):
-            token = create_token(username, issuer='API')
+            token = get_or_create_token(username, issuer='API')
             expireTime = token.issuedTime + auth_settings.TOKEN_EXPIRY_TIME
             auth_json = {
                 'token': token.key,


### PR DESCRIPTION
Solution: Fix the atomic transaction behavior.

If an integrity error is thrown, the reason will be that the object was already created.
In these instances, go ahead and re-attempt the atomic transaction.
Update django-cyverse-auth to 1.0.16 -- Fix atomic transaction block

Fixes #10 .