### PR TITLE
Fix incorrect usage of update_or_create

### DIFF
--- a/django_cyverse_auth/__init__.py
+++ b/django_cyverse_auth/__init__.py
@@ -2,5 +2,5 @@
 from collections import namedtuple
 
 version_info = namedtuple("version_info", ["major", "minor", "patch"])
-version = version_info(1, 1, 1)
+version = version_info(1, 1, 2)
 __version__ = "{0.major}.{0.minor}.{0.patch}".format(version)

--- a/django_cyverse_auth/models.py
+++ b/django_cyverse_auth/models.py
@@ -158,11 +158,14 @@ def get_or_create_token(user, token_key=None, token_expire=None, remote_ip=None,
     """
     token_expire = Token.update_expiration(token_expire)
     defaults = {
-        "issuer":issuer,
-        "expireTime":token_expire,
-        "remote_ip":remote_ip,
-        "api_server_url":auth_settings.API_SERVER_URL
+        "api_server_url": auth_settings.API_SERVER_URL
     }
+    if issuer:
+        defaults["issuer"] = issuer
+    if token_expire:
+        defaults["expireTime"] = token_expire
+    if remote_ip:
+        defaults["remote_ip"] = remote_ip
     auth_user_token, created = Token.objects.update_or_create(
         key=token_key, user=user, defaults=defaults)
     logger.info(
@@ -172,16 +175,15 @@ def get_or_create_token(user, token_key=None, token_expire=None, remote_ip=None,
     return auth_user_token
 
 
-def get_or_create_user(username=None, attributes={}):
+def get_or_create_user(username=None, attributes=None):
+    if not attributes:
+        attributes = {}
     User = get_user_model()
-    email = attributes.get('email', '%s@atmosphere.local' % username)
-    first_name = attributes.get('firstName')
-    last_name = attributes.get('lastName')
-    defaults = {
-        'email':email,
-        'first_name':first_name,
-        'last_name':last_name,
-    }
+    defaults = {}
+    if attributes.get('firstName'):
+        defaults['first_name'] = attributes.get('firstName')
+    if attributes.get('lastName'):
+        defaults['last_name'] = attributes.get('lastName')
     user, created =  User.objects.update_or_create(
         username=username,
         defaults=defaults)
@@ -231,7 +233,3 @@ def userCanEmulate(username):
         return user.is_staff
     except User.DoesNotExist:
         return False
-
-
-
-


### PR DESCRIPTION
#### Problem: 
The get_or_update calls were passed the wrong paramaters.

#### Solution: 
don't pass all fields to defaults, only the fields which are to be used to update the model

The fields in the defaults keyword are used to update the existing model. So
we want to make sure that the defaults dict contains values that are valid.