### PR TITLE
Docs: README to show keystone supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Protocols currently supported:
 - [x] CAS OAuth
 - [x] LDAP
 - [x] Mock (Override auth, always True)
+- [x] OpenStack Keystone


### PR DESCRIPTION
Simple patch for adding a line in the README