### PR TITLE
Fix excessive auth token creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/1.1.4...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix unnecessary session and token creation ([#20](https://github.com/cyverse/django-cyverse-auth/pull/20))


### PR DESCRIPTION
## Description
### Problem
Every api request to atmosphere creates a unique token and a new session. This token table and the session table are in the top 5 relations by size from several environments.

### Solution
Do not create a new session, whenever a user is authenticated

### Background
Normally authentication and login are separate. Authentication is the process of associating a user with a request, and login associates the user with a new session. In our authentication backend (TokenAuthentication) we were firing a login signal (equivalent to calling login). This meant that each api authentication created a new session.

It looks like we were firing the signal so that User.last_login would be updated whenever a user was authenticated. See https://github.com/cyverse/django-cyverse-auth/pull/17. However, neither atmosphere nor troposphere have any traces of referring to User.last_login

## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.