### PR TITLE
Prevent expired tokens from granting access to api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/1.1.4...HEAD) - YYYY-MM-DD
 ### Fixed
-  - Fix unnecessary session and token creation ([#20](https://github.com/cyverse/django-cyverse-auth/pull/20))
+  - Fix unnecessary session and token creation
+    ([#20](https://github.com/cyverse/django-cyverse-auth/pull/20))
+  - Prevent expired tokens from granting api access
+    ([#21](https://github.com/cyverse/django-cyverse-auth/pull/21))

--- a/django_cyverse_auth/token.py
+++ b/django_cyverse_auth/token.py
@@ -333,15 +333,7 @@ def validate_oauth_token(token, request=None):
     return auth_token
 
 
-def validate_token(token, request=None):
-    """
-    Validates the token attached to the request (SessionStorage, GET/POST)
-    If token has expired,
-    CAS will attempt to reauthenticate the user and refresh token.
-    Expired Tokens can be used for GET requests ONLY!
-    """
-
-    # Existence test
+def validate_token(token):
     if not token:
         return False
     try:

--- a/django_cyverse_auth/token.py
+++ b/django_cyverse_auth/token.py
@@ -360,22 +360,9 @@ def validate_token(token, request=None):
         logger.info("AuthToken Retrieved:%s Does not exist." % (token,))
         return False
     if auth_token.is_expired():
-        if request and request.META['REQUEST_METHOD'] != 'GET':
-            # See if the user (Or the user who is emulating a user) can be
-            # re-authed.
-            user_to_auth = request.session.get('emulated_by', user)
-            if cas_validateUser(user_to_auth):
-                auth_token.expireTime = AuthToken.update_expiration()
-                auth_token.save()
-                return True
-            else:
-                logger.info("Token %s expired, User %s "
-                            "could not be reauthenticated in CAS"
-                            % (token, user))
-                return False
-        else:
-            logger.debug("Token %s EXPIRED, but allowing User %s to GET data.."
-                         % (token, user))
-            return True
+	logger.info("Token %s expired, User %s "
+		    "could not be reauthenticated in CAS"
+		    % (token, user))
+	return False
     else:
         return True


### PR DESCRIPTION
## Description

In token authentication, we allow expired tokens to still make GET requests. So we check if the request is a GET. However, if there is no request, we accept the token. It turns out that the request is never passed as an argument to `validate_token`, thus all expired tokens would grant access.

Rather than just pass the missing paramater, I changed the behavior to disallow expired tokens from granting access.

See https://pods.iplantcollaborative.org/jira/browse/ATMO-2146

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.