### PR TITLE
Release 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 
-## [Unreleased](https://github.com/cyverse/django-cyverse-auth/compare/1.1.5...HEAD) - YYYY-MM-DD
+## [Unreleased](https://github.com/cyverse/django-cyverse-auth/compare/1.1.6...HEAD) - YYYY-MM-DD
+## [1.1.6](https://github.com/cyverse/django-cyverse-auth/compare/1.1.5...1.1.6) - 2018-08-31
+### Fixed
+  - Travis automatically pushes new pypi release when tags are pushed
+    ([#28](https://github.com/cyverse/django-cyverse-auth/pull/28))
+    ([#27](https://github.com/cyverse/django-cyverse-auth/pull/27))
+    ([#26](https://github.com/cyverse/django-cyverse-auth/pull/26))
+    ([#25](https://github.com/cyverse/django-cyverse-auth/pull/25))
+    ([#24](https://github.com/cyverse/django-cyverse-auth/pull/24))
+
 ## [1.1.5](https://github.com/cyverse/django-cyverse-auth/compare/1.1.4...1.1.5) - 2018-08-31
 ### Fixed
   - Fix unnecessary session and token creation

--- a/django_cyverse_auth/__init__.py
+++ b/django_cyverse_auth/__init__.py
@@ -2,5 +2,5 @@
 from collections import namedtuple
 
 version_info = namedtuple("version_info", ["major", "minor", "patch"])
-version = version_info(1, 1, 5)
+version = version_info(1, 1, 6)
 __version__ = "{0.major}.{0.minor}.{0.patch}".format(version)


### PR DESCRIPTION
This release is functionally equivalent to 1.1.5. Releasing a new version to test
automatic travis process.