### PR TITLE
Fix undefined reference 'user_logged_in'

### DIFF
--- a/django_cyverse_auth/token.py
+++ b/django_cyverse_auth/token.py
@@ -277,8 +277,6 @@ class OAuthTokenAuthentication(TokenAuthentication):
             oauth_token = auth[1]
             if 'django_cyverse_auth.authBackends.MockLoginBackend' in all_backends:
                 user, token = self._mock_oauth_login(oauth_token)
-                user_logged_in.send(
-                    sender=user.__class__, request=request, user=user)
                 return (user, token)
             if validate_oauth_token(oauth_token):
                 try:
@@ -286,10 +284,7 @@ class OAuthTokenAuthentication(TokenAuthentication):
                 except self.model.DoesNotExist:
                     return None
                 if token and token.user.is_active:
-                    user = token.user
-                    user_logged_in.send(
-                        sender=user.__class__, request=request, user=user)
-                    return (user, token)
+                    return (token.user, token)
         return None
 
 


### PR DESCRIPTION
## Description

In 86c67d2707, the user_logged_in import was removed, but there were still
some lingering references to it

To recap, we stopped using user_logged_in because it's an internal mechanism of
django. It serves the purpose of creating a session. If you create a session
during authentication (which happens every request), you'll create a session
every request which is unnecessary.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
