### PR TITLE
Add support for CAS 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/django-cyverse-auth/compare/1.1.7...HEAD) - YYYY-MM-DD
+### Added
+  - Added support for CAS 5
+    ([#32](https://github.com/cyverse/django-cyverse-auth/pull/32))
+
 ## [1.1.7](https://github.com/cyverse/django-cyverse-auth/compare/1.1.6...1.1.7) - 2018-09-18
 ### Fixed
   - Remove undefined reference to 'user_logged_in'

--- a/django_cyverse_auth/protocol/cas.py
+++ b/django_cyverse_auth/protocol/cas.py
@@ -321,5 +321,5 @@ def cas_profile_contains(attrs, test_value):
 
 def cas_profile_for_token(access_token):
     oauth_client = get_cas_oauth_client()
-    profile_map = oauth_client.get_profile(access_token)
-    return profile_map
+    profile = oauth_client.get_profile(access_token)
+    return profile

--- a/django_cyverse_auth/token.py
+++ b/django_cyverse_auth/token.py
@@ -302,25 +302,18 @@ def validate_oauth_token(token, request=None):
 
     if not user_profile:
         return False
-    username = user_profile.get("id")
+    username = user_profile.get("username")
     if not username:
         logger.warn("Invalid Profile:%s does not have username/attributes"
                     % user_profile)
         return False
 
-    # CAS specific:
-    # converts [{u'lastName': u'Doe'}, {u'firstName': u'John'}]
-    # to {u'lastName': u'doe', u'firstName': u'John'}
-    profile_attrs = {
-        c.keys()[0]: c.values()[0]
-        for c in user_profile.get('attributes', [])
-    }
     username = username.lower()
     new_profile = {
         'username': username,
-        'firstName': profile_attrs['firstName'],
-        'lastName': profile_attrs['lastName'],
-        'email': profile_attrs['email']
+        'firstName': user_profile['firstName'],
+        'lastName': user_profile['lastName'],
+        'email': user_profile['email']
     }
     user = get_or_create_user(new_profile['username'], new_profile)
     auth_token = get_or_create_token(

--- a/django_cyverse_auth/views.py
+++ b/django_cyverse_auth/views.py
@@ -114,7 +114,7 @@ def cas_callback_authorize(request):
         return o_login_redirect(request)
     # Exchange token for profile
     user_profile = oauth_client.get_profile(access_token)
-    if not user_profile or "id" not in user_profile:
+    if not user_profile or "username" not in user_profile:
         logger.error("AccessToken is producing an INVALID profile!"
                      " Check the CAS server and caslib.py for more"
                      " information.")
@@ -122,7 +122,7 @@ def cas_callback_authorize(request):
         return login(request)
     # ASSERT: A valid OAuth token gave us the Users Profile.
     # Now create an AuthToken and return it
-    username = user_profile["id"]
+    username = user_profile["username"]
     auth_token = get_or_create_token(username, access_token, expiry_date, issuer="CAS+OAuth")
     # Set the username to the user to be emulated
     # to whom the token also belongs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-caslib.py
+caslib.py >= 2.3.0
 apache-libcloud
 oauth2client
 djangorestframework


### PR DESCRIPTION
## Description
Upgrade to caslib.py (2.3.0) to support CAS 5

The only notable change, is that caslib.py's cas_oauth_client.get_profile returns a profile dict, when before it returned the raw response from the cas api.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.